### PR TITLE
Electronics Time Improvements:

### DIFF
--- a/src/NuttyTree.NetDaemon.Application/ElectronicsTime/Models/RecurringToDoListItem.cs
+++ b/src/NuttyTree.NetDaemon.Application/ElectronicsTime/Models/RecurringToDoListItem.cs
@@ -6,6 +6,8 @@ internal sealed class RecurringToDoListItem
 
     public RecurringToDoListItemType RecurringToDoListItemType { get; set; }
 
+    public bool IsOptional { get; set; }
+
     public TimeOnly StartAt { get; set; }
 
     public DayOfWeek WeeklyDayOfWeek { get; set; }

--- a/src/NuttyTree.NetDaemon.Infrastructure/HomeAssistant/Extensions/TodoEntityExtensions.cs
+++ b/src/NuttyTree.NetDaemon.Infrastructure/HomeAssistant/Extensions/TodoEntityExtensions.cs
@@ -23,29 +23,36 @@ public static class TodoEntityExtensions
         using var stateChange = entity.StateChanges().Subscribe(_ => itemIsCreated.TrySetResult());
         entity.AddItem(item, dueDate, dueDatetime, description);
         await itemIsCreated.Task.WaitAsync(cancellationToken);
-        var updatedItems = await entity.GetItemsAsync("needs_action");
-        return updatedItems.First(u => u.Summary == item);
+        var updatedItems = await entity.GetItemsAsync(ToDoListItemStatus.needs_action);
+        return updatedItems.Last(u => u.Summary == item);
     }
 
-    public static async Task<ICollection<TodoListItem>> GetItemsAsync(this TodoEntity entity, string? status = null)
+    public static async Task<ICollection<TodoListItem>> GetItemsAsync(this TodoEntity entity, ToDoListItemStatus? status = null)
     {
         var response = await entity.HaContext.CallServiceWithResponseAsync(
             "todo",
             "get_items",
             entity.ToServiceTarget(),
-            new { status });
+            new { status = $"{status}" });
         return response == null
             ? Array.Empty<TodoListItem>()
             : JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, ICollection<TodoListItem>>>>(response.Value, SerializerOptions) !.First().Value["items"];
     }
 
-    public static void UpdateItem(this TodoEntity entity, Guid id, string status)
+    public static void UpdateItem(
+        this TodoEntity entity,
+        Guid uid,
+        string? name = null,
+        ToDoListItemStatus? status = null,
+        object? dueDate = null,
+        object? dueDatetime = null,
+        string? description = null)
     {
-        entity.UpdateItem($"{id}", status: status);
+        entity.UpdateItem($"{uid}", name, $"{status}", dueDate, dueDatetime, description);
     }
 
-    public static void RemoveItem(this TodoEntity entity, Guid id)
+    public static void RemoveItem(this TodoEntity entity, Guid uid)
     {
-        entity.RemoveItem($"{id}");
+        entity.RemoveItem($"{uid}");
     }
 }

--- a/src/NuttyTree.NetDaemon.Infrastructure/HomeAssistant/Models/ToDoListItemStatus.cs
+++ b/src/NuttyTree.NetDaemon.Infrastructure/HomeAssistant/Models/ToDoListItemStatus.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace NuttyTree.NetDaemon.Infrastructure.HomeAssistant.Models;
+
+[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Name must match Home Assistant")]
+[SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Name must match Home Assistant")]
+public enum ToDoListItemStatus
+{
+    needs_action,
+    completed
+}

--- a/src/NuttyTree.NetDaemon.Infrastructure/HomeAssistant/Models/TodoListItem.cs
+++ b/src/NuttyTree.NetDaemon.Infrastructure/HomeAssistant/Models/TodoListItem.cs
@@ -2,7 +2,7 @@
 
 public sealed class TodoListItem
 {
-    public TodoListItem(Guid uid, string summary, string description, string status, DateTime? due = null)
+    public TodoListItem(Guid uid, string summary, string description, ToDoListItemStatus status, DateTime? due = null)
     {
         Uid = uid;
         Summary = summary;
@@ -17,7 +17,7 @@ public sealed class TodoListItem
 
     public string Description { get; set; }
 
-    public string Status { get; set; }
+    public ToDoListItemStatus Status { get; set; }
 
     public DateTime? Due { get; set; }
 }

--- a/tests/NuttyTree.NetDaemon.Application.UnitTests/NuttyTree.NetDaemon.Application.UnitTests.csproj
+++ b/tests/NuttyTree.NetDaemon.Application.UnitTests/NuttyTree.NetDaemon.Application.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.4.0" />
+    <PackageReference Include="Bogus" Version="35.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.7.0" />


### PR DESCRIPTION
* Added a ToDoItemItemStatus enum
* Update the ToDoListItem model to use the ToDoItemItemStatus enum for the status instead of a string
* AddItemAsync returns the last matching item instead of the first
* Update id parameter of RemoveItem to uid to match Home Assistant
* Update status parameter of GetItemsAsync to use the ToDoItemItemStatus enum instead of a string
* Add UpdateItem extension method that uses the ToDoItemItemStatus enum for the status instead of a string
* Review items now have the completion day/time in the description instead of the summary
* Invalid completion of review items also changes the minutes earned to 0
* When an item expires it is deleted from the database instead of nulling out the expiration date
* Add an IsOptional property to recurring items
* AddNewToDoListItemAsync adds to the correct list based on the IsOptional property
* AddNewToDoListItemAsync checks if the item already exists and does not add a duplicate
* Update Bogus NuGet